### PR TITLE
Fix issue comment formatting

### DIFF
--- a/grails-app/controllers/cavamedia/VideoUploadController.groovy
+++ b/grails-app/controllers/cavamedia/VideoUploadController.groovy
@@ -132,7 +132,7 @@ class VideoUploadController {
         ## Overview
         ${params.body}
 
-        ## Detail
+        ## Details
         Sender: ${params.name}
         Sender email: ${params.email}
         Question type: ${params.labels}


### PR DESCRIPTION
## Overview

This PR fixes issue formatting for form feedback. It clears up the indents that causes markdown to not be rendered properly and remove repetition of title. Now the comment body is where it should be.