### PR TITLE
added the portal api to allowed domains

### DIFF
--- a/grails-app/conf/application.groovy
+++ b/grails-app/conf/application.groovy
@@ -81,5 +81,5 @@ swagger {
     //consumes = ["application/json"]
 }
 
-trustedURLs = ['interactiveoceans.washington.edu', 'api-development.ooica.net', 'localhost:8080']
+trustedURLs = ['interactiveoceans.washington.edu', 'api-development.ooica.net', 'api.interactiveoceans.washington.edu', 'localhost:8080']
 


### PR DESCRIPTION
api.interactiveoceans.washington.edu can now make api calls into the app.